### PR TITLE
Use read-only git:// schema for submodules.

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,3 @@
 [submodule "vendor/assets/javascripts/nvd3"]
 	path = vendor/assets/javascripts/nvd3
-	url = git@github.com:adeven/nvd3.git
+	url = git://github.com/adeven/nvd3.git


### PR DESCRIPTION
This enables the use of the gem on servers without GitHub
access keys.
