### PR TITLE
Original novus nvd3 project

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,3 @@
 [submodule "vendor/assets/javascripts/nvd3"]
 	path = vendor/assets/javascripts/nvd3
-	url = git://github.com/adeven/nvd3.git
+	url = git://github.com/novus/nvd3.git


### PR DESCRIPTION
once adeven/adjust#1255 is merged this can also be merged - it changes back to the [original nvd3 project](www.github.com/novus/nvd3) instead of using adeven's fork thereof.
